### PR TITLE
Enable snort on arm64

### DIFF
--- a/daq/daq-2.0.6/debian/control
+++ b/daq/daq-2.0.6/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.snort.org/snort-downloads
 
 Package: libdaq-dev
 Section: libdevel
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 Depends: libdaq0 (= ${binary:Version})
 Description: Data Acquisition library for packet I/O - development files
  DAQ is a library that introduces an abstraction layer to PCAP functions
@@ -21,7 +21,7 @@ Description: Data Acquisition library for packet I/O - development files
 
 Package: libdaq0
 Section: libs
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Data Acquisition library for packet I/O - shared library
  DAQ is a library that introduces an abstraction layer to PCAP functions

--- a/daq/daq-2.0.6/debian/rules
+++ b/daq/daq-2.0.6/debian/rules
@@ -11,5 +11,5 @@
 export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@  --with autoreconf
 #	dh $@  --with quilt

--- a/snort/snort-2.9.8.2/debian/control
+++ b/snort/snort-2.9.8.2/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
     libnet1-dev, 
     libpcap0.8-dev, 
     libpcre3-dev, 
-    debhelper (>= 5.0.0), 
+    debhelper (>= 9.20160402),
     libpq-dev, 
     po-debconf (>= 0.5.0), 
     libprelude-dev, 

--- a/snort/snort-2.9.8.2/debian/control
+++ b/snort/snort-2.9.8.2/debian/control
@@ -35,7 +35,7 @@ Vcs-Git: git://git.debian.org/git/pkg-snort/pkg-snort.git
 Vcs-Browser: http://anonscm.debian.org/gitweb/?p=pkg-snort/pkg-snort.git
 
 Package: snort
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 Pre-Depends: adduser (>= 3.11)
 Depends: 
     snort-common-libraries (>=${binary:Version}),
@@ -127,7 +127,7 @@ Description: flexible Network Intrusion Detection System ruleset
  or using the oinkmaster package.
 
 Package: snort-common-libraries
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Suggests: snort (>= 2.7.0) | snort-pgsql (>= 2.7.0) | snort-mysql (>= 2.7.0)
 Conflicts: snort-common (<< 2.7.0-6)

--- a/snort/snort-2.9.8.2/debian/rules
+++ b/snort/snort-2.9.8.2/debian/rules
@@ -28,8 +28,8 @@ CONFFLAGS= --prefix=/usr \
 	--with-daq-includes=$(DAQ_DEV_PATH)/usr/include
 
 aclocal.m4:
-	aclocal-1.14 -I m4/
-	automake-1.14 -i
+	aclocal -I m4/
+	automake -i
 	autoconf
 
 clean-sources:
@@ -59,8 +59,11 @@ clean: clean-sources
 	dh_autoreconf_clean
 	dh_clean
 
-configure: configure-stamp
+configure:
+	configure-stamp
+
 configure-stamp:
+	dh_autoreconf
 	dh_testdir
 # Standard package support
 	./configure $(CONFFLAGS) \
@@ -97,6 +100,7 @@ build-inline: build-inline-stamp
 build-inline-stamp:
 	dh_testdir
 	sh debian/clean_sources.sh
+	dh_autoreconf
 	# Inline support
 	./configure $(CONFFLAGS) \
 		--without-mysql \
@@ -146,7 +150,7 @@ install-arch:
 	find $(TMP)/snort-common/usr/lib  -name "*.la" -exec \
 		sed -i -e "s,^dependency_libs=.*,dependency_libs=''," {} +
 # Snort binaries
-	install -m 755 -o root -g root src/snort-basic $(TMP)/snort/usr/sbin/snort
+	install -D -m 755 -o root -g root src/snort-basic $(TMP)/snort/usr/sbin/snort
 #	install -m 755 -o root -g root src/snort-mysql $(TMP)/snort-mysql/usr/sbin/snort
 #	install -m 755 -o root -g root src/snort-pgsql $(TMP)/snort-pgsql/usr/sbin/snort
 #	install -m 755 -o root -g root src/snort-inline   $(TMP)/snort/usr/sbin/snort
@@ -154,18 +158,18 @@ install-arch:
 #	install -m 644 -o root -g root `pwd`/debian/snort.common.parameters $(TMP)/snort-mysql/etc/snort/snort.common.parameters
 #	install -m 644 -o root -g root `pwd`/debian/snort.common.parameters $(TMP)/snort-pgsql/etc/snort/snort.common.parameters
 #	install -m 644 -o root -g root `pwd`/debian/snort.common.parameters $(TMP)/snort/etc/snort/snort.common.parameters
-	install -m 644 -o root -g root `pwd`/debian/snort.default $(TMP)/snort/etc/default/snort
+	install -D -m 644 -o root -g root `pwd`/debian/snort.default $(TMP)/snort/etc/default/snort
 #	install -m 644 -o root -g root `pwd`/debian/snort.default $(TMP)/snort-mysql/etc/default/snort
 #	install -m 644 -o root -g root `pwd`/debian/snort.default $(TMP)/snort-pgsql/etc/default/snort
 #	install -m 644 -o root -g root `pwd`/debian/snort.default $(TMP)/snort-inline/etc/default/snort
 #  Install init.d initscripts
-	install -m 755 -o root -g root `pwd`/debian/snort.init.d $(TMP)/snort/etc/init.d/snort
+	install -D -m 755 -o root -g root `pwd`/debian/snort.init.d $(TMP)/snort/etc/init.d/snort
 #	install -m 755 -o root -g root `pwd`/debian/snort.init.d $(TMP)/snort-mysql/etc/init.d/snort
 #	install -m 755 -o root -g root `pwd`/debian/snort.init.d $(TMP)/snort-pgsql/etc/init.d/snort
 #	install -m 755 -o root -g root `pwd`/debian/snort.init.d $(TMP)/snort-inline/etc/init.d/snort
 #  Install PPP initscripts
-	install -m 755 -o root -g root `pwd`/debian/my/snort.ip-up.d $(TMP)/snort/etc/ppp/ip-up.d/snort
-	install -m 755 -o root -g root `pwd`/debian/my/snort.ip-down.d $(TMP)/snort/etc/ppp/ip-down.d/snort
+	install -D -m 755 -o root -g root `pwd`/debian/my/snort.ip-up.d $(TMP)/snort/etc/ppp/ip-up.d/snort
+	install -D -m 755 -o root -g root `pwd`/debian/my/snort.ip-down.d $(TMP)/snort/etc/ppp/ip-down.d/snort
 #	install -m 755 -o root -g root `pwd`/debian/my/snort.ip-up.d $(TMP)/snort-mysql/etc/ppp/ip-up.d/snort
 #	install -m 755 -o root -g root `pwd`/debian/my/snort.ip-down.d $(TMP)/snort-mysql/etc/ppp/ip-down.d/snort
 	# install -m 755 -o root -g root `pwd`/debian/my/snort.ip-up.d $(TMP)/snort-pgsql/etc/ppp/ip-up.d/snort
@@ -173,11 +177,12 @@ install-arch:
 #	install -m 755 -o root -g root `pwd`/debian/my/snort.ip-up.d $(TMP)/snort-inline/etc/ppp/ip-up.d/snort
 #	install -m 755 -o root -g root `pwd`/debian/my/snort.ip-down.d $(TMP)/snort-inline/etc/ppp/ip-down.d/snort
 # Logrotate files
-	install -m 644 -o root -g root `pwd`/debian/snort.logrotate $(TMP)/snort/etc/logrotate.d/snort
+	install -D -m 644 -o root -g root `pwd`/debian/snort.logrotate $(TMP)/snort/etc/logrotate.d/snort
 #	install -m 644 -o root -g root `pwd`/debian/snort.logrotate $(TMP)/snort-mysql/etc/logrotate.d/snort
 #	install -m 644 -o root -g root `pwd`/debian/snort.logrotate $(TMP)/snort-pgsql/etc/logrotate.d/snort
 #	install -m 644 -o root -g root `pwd`/debian/snort.logrotate $(TMP)/snort-inline/etc/logrotate.d/snort
 # Move libraries to the snort-common-libraries package
+	install -o root -g root -d $(TMP)/snort-common-libraries/usr/
 	mv $(TMP)/snort-common/usr/lib/ $(TMP)/snort-common-libraries/usr/
 # Remove headers, as this is not a -dev package
 #	mv $(TMP)/snort-common/usr/src/ $(TMP)/snort-common-libraries/usr/

--- a/snort/snort-2.9.8.2/debian/rules
+++ b/snort/snort-2.9.8.2/debian/rules
@@ -59,9 +59,7 @@ clean: clean-sources
 	dh_autoreconf_clean
 	dh_clean
 
-configure:
-	configure-stamp
-
+configure: configure-stamp
 configure-stamp:
 	dh_autoreconf
 	dh_testdir


### PR DESCRIPTION
These changes enable snort (and its daq library) on arm64.

I had a bit of trouble with the configure scripts either not recognizing arm64 or requiring an older aclocal/automake than debian/arm64 ships. Forcing autoreconf seems to fix these issues, but requires the debhelper version of the package to be incremented as well.

Note that I am building these with my own scripts so your package scripts might have handled this already.


